### PR TITLE
Fix data placeholder equality

### DIFF
--- a/bsst/__init__.py
+++ b/bsst/__init__.py
@@ -4675,11 +4675,11 @@ class SymData:
             while True:
                 for other_cr, other_entry in g_data_reference_names_table.items():
                     if other_cr != cr and dr in other_entry:
-                        did_altname = f"{dr}'"
+                        dr_altname = f"{dr}'"
                         if dr == data_reference:
-                            data_reference = did_altname
+                            data_reference = dr_altname
 
-                        dr = did_altname
+                        dr = dr_altname
                         break
                 else:
                     break
@@ -8041,9 +8041,9 @@ def data_reference_names_show() -> None:
 
     def get_data_reference_names_rec() -> list[tuple[list[str], str]]:
         result: list[tuple[list[str], str]] = []
-        did_copy = g_data_reference_names_table.copy()
+        drn_copy = g_data_reference_names_table.copy()
 
-        for _, vndict in did_copy.items():
+        for _, vndict in drn_copy.items():
             data_reference_names: list[str] = []
             for dr, (value, ctx) in vndict.items():
                 if dr not in seen_data_reference_names:

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -3,6 +3,7 @@
 set -ex
 
 ./test_integer_conversion.py
+./test_data_placeholders.py
 ./test_varnames.py
 ./test_elements_script_tests.py ./script_tests_tapscript_opcodes.json tapscript
 if [ ! -e script_tests.json ]; then

--- a/tests/test_data_placeholders.py
+++ b/tests/test_data_placeholders.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+import sys
+
+from io import StringIO
+
+from contextlib import contextmanager
+from typing import Generator
+
+import bsst
+
+testcase = """
+$a 1 add
+$a 2 add 1 sub
+equal
+"""
+
+
+expected_result = """
+============
+Valid paths:
+============
+
+[Root]
+------
+
+==============================
+Enforced constraints per path:
+==============================
+
+All valid paths:
+----------------
+
+        <*> EQUAL(ADD($a, 1), SUB(ADD($a, 2), 1)) @ END
+
+==================================
+Witness usage for all valid paths:
+==================================
+Witnesses used: 0
+
+"""
+
+
+@contextmanager
+def CaptureStdout() -> Generator[StringIO, None, None]:
+    save_stdout = sys.stdout
+    out = StringIO()
+    sys.stdout = out
+    yield out
+    sys.stdout = save_stdout
+
+
+@contextmanager
+def FreshEnv() -> Generator[None, None, None]:
+    env = bsst.SymEnvironment()
+    env.use_parallel_solving = False
+    env.log_progress = False
+    env.solver_timeout_seconds = 0
+    env.z3_enabled = True
+    env.produce_model_values = False
+
+    with bsst.CurrentEnvironment(env):
+        bsst.try_import_optional_modules()
+        bp = bsst.Branchpoint(pc=0, branch_index=0)
+        with bsst.CurrentExecContext(bp.context):
+            yield
+
+
+def test() -> None:
+    with FreshEnv():
+        (bsst.g_script_body,
+         bsst.g_line_no_table,
+         bsst.g_var_save_positions) = bsst.get_opcodes(testcase.split('\n'))
+
+        out: str = ''
+        with CaptureStdout() as output:
+            bsst.g_is_in_processing = True
+            bsst.symex_script()
+            bsst.g_is_in_processing = False
+            bsst.report()
+            out = output.getvalue()
+
+        if out != expected_result:
+            print("NO MATCH")
+            print("_____________________________________")
+            print("Script:")
+            print("_____________________________________")
+            print(testcase)
+            print("_____________________________________")
+            print("Expected:")
+            print("_____________________________________")
+            print(expected_result)
+            print("_____________________________________")
+            print("Got:")
+            print("_____________________________________")
+            print(out)
+            print("_____________________________________")
+            sys.exit(-1)
+
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
Ensures that data placeholders with same names are represented by the same instances of `SymData`

Also improves equality checks - for `EQUAL`, if both arguments were used as integers before, and `minimaldata_flag` is true, then it compares `_Int` versions of the data rather than `_ByteSeq` versions. It still enforces that "integer" equality matches "bytes" equality, just in case.

Fixes #16 